### PR TITLE
ci - skip coverage upload for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,96 +7,23 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "06:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     reviewers:
       - "4fra"
       - "Danrejk"
     assignees:
       - "4fra"
-      - "Danrejk"
     labels:
       - "dependencies"
       - "automated"
     commit-message:
       prefix: "chore"
       include: "scope"
-    # Group updates by type to reduce PR noise
+    # Group all updates into a single PR
     groups:
-      # Group all development/tooling dependencies
-      development-dependencies:
-        patterns:
-          - "@types/*"
-          - "@babel/*"
-          - "@eslint/*"
-          - "eslint*"
-          - "prettier*"
-          - "stylelint*"
-          - "jest*"
-          - "@testing-library/*"
-          - "@storybook/*"
-          - "storybook"
-          - "postcss*"
-          - "ts-jest"
-          - "typescript"
-          - "typescript-eslint"
-          - "babel-loader"
-        update-types:
-          - "minor"
-          - "patch"
-      # Group React ecosystem updates
-      react-dependencies:
-        patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-        update-types:
-          - "minor"
-          - "patch"
-      # Group Next.js ecosystem updates
-      nextjs-dependencies:
-        patterns:
-          - "next"
-          - "eslint-config-next"
-          - "@next/*"
-        update-types:
-          - "minor"
-          - "patch"
-      # Group Mantine UI framework updates
-      mantine-dependencies:
-        patterns:
-          - "@mantine/*"
-          - "postcss-preset-mantine"
-        update-types:
-          - "minor"
-          - "patch"
-      # Group all other production dependencies
-      production-dependencies:
+      all-dependencies:
         patterns:
           - "*"
-        exclude-patterns:
-          - "@types/*"
-          - "@babel/*"
-          - "@eslint/*"
-          - "eslint*"
-          - "prettier*"
-          - "stylelint*"
-          - "jest*"
-          - "@testing-library/*"
-          - "@storybook/*"
-          - "storybook"
-          - "postcss*"
-          - "ts-jest"
-          - "typescript"
-          - "typescript-eslint"
-          - "babel-loader"
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "next"
-          - "eslint-config-next"
-          - "@next/*"
-          - "@mantine/*"
-          - "postcss-preset-mantine"
         update-types:
           - "minor"
           - "patch"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,8 +34,10 @@ jobs:
         run: npx jest --coverage
 
       - name: Upload coverage reports to Codecov
+        # Skip upload for Dependabot PRs as secrets are not available
+        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
## Proposed Changes

- skip Codecov upload for Dependabot
- disable CI fail if error
- disable Dependabot group

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline stability by allowing coverage uploads to fail gracefully without blocking builds.
  * Coverage reports are now skipped during automated dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->