### PR TITLE
chore(deps): update dependencies label format

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
     assignees:
       - "4fra"
     labels:
-      - "dependencies"
+      - "type: Dependencies"
       - "automated"
     commit-message:
       prefix: "chore"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,7 @@ updates:
       day: "monday"
       time: "06:00"
     labels:
-      - "dependencies"
+      - "type: Dependencies"
       - "github-actions"
     commit-message:
       prefix: "ci"


### PR DESCRIPTION
resolves none

## Proposed Changes

- Dependabot will now use the label `type: Dependencies` instead of `dependencies`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to standardize labels for automated updates.

**Note:** This release contains no user-facing behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->